### PR TITLE
Update checksum for promtail_linux_amd64.gz v0.3.0

### DIFF
--- a/data/kernel/Linux.yaml
+++ b/data/kernel/Linux.yaml
@@ -1,2 +1,3 @@
 ---
-promtail::checksum: '9f0631b431f7a317083a2c89386f9a758562160bac2e9c8e964278bd1debe0ff'
+promtail::checksum: '7431540932ede248310d2b3d4c8ef99ed594a636b76de04fa91a117441d874f7'
+


### PR DESCRIPTION
Grafana seems to have rebuilt and reuploaded this version which caused the checksum to change....