### PR TITLE
Switch configuration to concat fragments from monolithic setting

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -4,5 +4,6 @@
 fixtures:
   forge_modules:
     archive: 'puppet/archive'
+    concat: 'puppetlabs/concat'
     systemd: 'camptocamp/systemd'
     stdlib: 'puppetlabs/stdlib'

--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,6 @@
 /.bundle/
 /.idea/
 /.vagrant/
-/Vagrantfile
 /coverage/
 /bin/
 /doc/

--- a/.pdkignore
+++ b/.pdkignore
@@ -7,7 +7,6 @@
 /.bundle/
 /.idea/
 /.vagrant/
-/Vagrantfile
 /coverage/
 /bin/
 /doc/

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -27,6 +27,7 @@ GetText/DecorateString:
   Description: We don't want to decorate test output.
   Exclude:
   - spec/**/*
+  Enabled: false
 RSpec/BeforeAfterAll:
   Description: Beware of using after(:all) as it may cause state to leak between tests.
     A necessary evil in acceptance testing.
@@ -88,6 +89,12 @@ Style/MethodCalledOnDoEndBlock:
   Enabled: true
 Style/StringMethods:
   Enabled: true
+GetText/DecorateFunctionMessage:
+  Enabled: false
+GetText/DecorateStringFormattingUsingInterpolation:
+  Enabled: false
+GetText/DecorateStringFormattingUsingPercent:
+  Enabled: false
 Layout/EndOfLine:
   Enabled: false
 Layout/IndentHeredoc:

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,9 @@
+Vagrant.configure('2') do |config|
+  config.vm.box = 'genebean/centos-7-puppet-latest'
+  config.vm.network 'forwarded_port', guest: 3000, host: 3000
+  config.vm.provision 'shell', inline: <<-SCRIPT
+    puppet resource file /etc/puppetlabs/code/environments/production/modules/promtail ensure=link target=/vagrant force=true
+    /opt/puppetlabs/puppet/bin/gem install puppet-moddeps
+    /opt/puppetlabs/puppet/bin/puppet-moddeps promtail
+  SCRIPT
+end

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -7,4 +7,5 @@ lookup_options:
     convert_to: 'Sensitive'
 
 promtail::bin_dir: '/usr/local/bin'
+promtail::service_ensure: 'running'
 promtail::version: 'v0.3.0'

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -1,3 +1,10 @@
 ---
+lookup_options:
+  '^promtail::(.+)_config(s)?_hash$':
+    merge:
+      strategy: deep
+  '^promtail::password_file_content$':
+    convert_to: 'Sensitive'
+
 promtail::bin_dir: '/usr/local/bin'
 promtail::version: 'v0.3.0'

--- a/data/kernel/Linux.yaml
+++ b/data/kernel/Linux.yaml
@@ -1,3 +1,2 @@
 ---
 promtail::checksum: '7431540932ede248310d2b3d4c8ef99ed594a636b76de04fa91a117441d874f7'
-

--- a/hiera.yaml
+++ b/hiera.yaml
@@ -6,7 +6,7 @@ defaults:  # Used for any hierarchy level that omits these keys.
   data_hash: yaml_data  # Use the built-in YAML backend.
 
 hierarchy:
-  - name: "kermel"
+  - name: 'kermel'
     path: "kernel/%{facts.kernel}.yaml"
   - name: 'common'
     path: 'common.yaml'

--- a/lib/puppet/functions/promtail/strip_yaml_header.rb
+++ b/lib/puppet/functions/promtail/strip_yaml_header.rb
@@ -1,0 +1,22 @@
+# A function to strip the --- from the beginning of a string
+Puppet::Functions.create_function(:'promtail::strip_yaml_header') do
+  # @param [String] yaml_string
+  #   A string that may start with the ---'s used to denote a YAML file
+  # @return [String]
+  #   Returns the string with the leading header stripped off
+  # @example
+  #   concat::fragment { 'server_config_hash':
+  #     target  => $config_file,
+  #     content => $promtail::server_config_hash.promtail::to_yaml.promtail::strip_yaml_header,
+  #     order   => '10',
+  #   }
+  #
+  dispatch :strip_header do
+    param 'String', :yaml_string
+    return_type 'String'
+  end
+
+  def strip_header(yaml_string)
+    yaml_string.gsub(%r{^---\s}, '')
+  end
+end

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -11,15 +11,67 @@ class promtail::config {
     default: { fail("${facts['kernel']} is not supported")}
   }
 
-  file {
-    $config_dir:
-      ensure => directory,
-    ;
-    "${config_dir}/config.yaml":
-      ensure  => file,
-      content => promtail::to_yaml($promtail::config_hash),
-      notify  => Service['promtail'],
-    ;
+  file { $config_dir:
+    ensure => directory,
+  }
+
+  $config_file = "${config_dir}/config.yaml"
+
+  concat { $config_file:
+    ensure => present,
+    notify => Service['promtail'],
+  }
+
+  concat::fragment { 'config_header':
+    target  => $config_file,
+    content => "---\n",
+    order   => '01',
+  }
+
+  # Configures the server for Promtail.
+  # [server: <server_config>]
+  if $promtail::server_config_hash {
+    concat::fragment { 'server_config_hash':
+      target  => $config_file,
+      content => $promtail::server_config_hash.promtail::to_yaml.promtail::strip_yaml_header,
+      order   => '10',
+    }
+  }
+
+  # Describes how Promtail connects to multiple instances
+  # of Loki, sending logs to each.
+  # clients:
+  #   - [<client_config>]
+  concat::fragment { 'clients_config_hash':
+    target  => $config_file,
+    content => $promtail::clients_config_hash.promtail::to_yaml.promtail::strip_yaml_header,
+    order   => '20',
+  }
+
+  # Describes how to save read file offsets to disk
+  # [positions: <position_config>]
+  concat::fragment { 'positions_config_hash':
+    target  => $config_file,
+    content => $promtail::positions_config_hash.promtail::to_yaml.promtail::strip_yaml_header,
+    order   => '30',
+  }
+
+  # scrape_configs:
+  #   - [<scrape_config>]
+  concat::fragment { 'scrape_configs_hash':
+    target  => $config_file,
+    content => $promtail::scrape_configs_hash.promtail::to_yaml.promtail::strip_yaml_header,
+    order   => '40',
+  }
+
+  # Configures how tailed targets will be watched.
+  # [target_config: <target_config>]
+  if $promtail::target_config_hash {
+    concat::fragment { 'target_config_hash':
+      target  => $config_file,
+      content => $promtail::target_config_hash.promtail::to_yaml.promtail::strip_yaml_header,
+      order   => '50',
+    }
   }
 
   if $promtail::password_file_path and $promtail::password_file_content {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -4,73 +4,114 @@
 # module is intended to install and configure Grafana's promtail tool for shipping
 # logs to Loki.
 #
-# @param [Hash] config_hash
-#   A hash representing the configuration to be used by promtail.
-#   See https://github.com/grafana/loki/blob/master/docs/clients/promtail/configuration.md#example-journal-config
-#   for all paramters.
+# @param [Enum['running', 'stopped']] service_ensure
+#   The value passed to the service resource's ensure parameter for promtail's service
+#
+# @param [Hash] clients_config_hash
+#   Describes how Promtail connects to multiple instances of Loki, sending logs to each.
+#   See https://github.com/grafana/loki/blob/master/docs/clients/promtail/configuration.md
+#   for all parameters.
+#
+# @param [Hash] positions_config_hash
+#   Describes how to save read file offsets to disk.
+#   See https://github.com/grafana/loki/blob/master/docs/clients/promtail/configuration.md
+#   for all parameters.
+#
+# @param [Hash] scrape_configs_hash
+#   Each scrape_config block configures how Promtail can scrape logs from a series of targets
+#   using a specified discovery method.
+#   See https://github.com/grafana/loki/blob/master/docs/clients/promtail/configuration.md
+#   for all parameters.
+#
 # @param [Stdlib::Absolutepath] bin_dir
 #   The directory in which to create a symlink to the promtail binary
+#
 # @param [String[1]] checksum
 #   The checksum of the promtail binary.
 #   Note: each platform has its own checksum.
 #   Values can be found with each release on GitHub
+#
 # @param [String[1]] version
 #   The version as listed on the GitHub release page
 #   See https://github.com/grafana/loki/releases for a list
+#
+# @param [Optional[Hash]] server_config_hash
+#   Configures Promtail's behavior as an HTTP server. Defaults will be used if this block
+#   is omitted.
+#   See https://github.com/grafana/loki/blob/master/docs/clients/promtail/configuration.md
+#   for all parameters.
+#
+# @param [Optional[Hash]] target_config_hash
+#   Configures how tailed targets will be watched. Defaults will be used if this block
+#   is omitted.
+#   See https://github.com/grafana/loki/blob/master/docs/clients/promtail/configuration.md
+#   for all parameters.
+#
 # @param [Optional[Stdlib::Absolutepath]] $password_file_path
 #   The fully qualified path to the file containing the password used for basic auth
-# @param [Optional[Sensitive[String[1]]]] $password_file_content
-#   The value to be placed in the password file.
 #
-# @example Config settings in Hiera
+# @param [Optional[Sensitive[String[1]]]] $password_file_content
+#   The value to be placed in the password file. This value is cast to Sensitive via
+#   lookup_options defined in data/common.yaml
+#
+# @example
 #   include promtail
 #
-# @example eyaml encrypted password in Hiera
-#   ---
-#   lookup_options:
-#     '^promtail::password_file_content$':
-#       convert_to: 'Sensitive'
-#
-#   promtail::password_file_content: ENC[PKCS7,MIIBasdfasdfasdfasdfasdfasdf==]
-#
-# @example In-manifest config
-#   $config_hash = {
-#     'client'         => {
-#       'url'        => 'https://logs-us-west1.grafana.net/api/prom/push',
-#       'basic_auth' => {
-#         'username'      => '1234',
-#         'password_file' => '/etc/promtail/.gc_pw',
-#       },
-#     },
-#     'scrape_configs' => [
-#       {
-#         'job_name'       => 'system',
-#         'entry_parser'   => 'raw',
-#         'static_configs' => [
-#           {
-#             'targets' => [ 'localhost' ],
-#             'labels'  => {
-#               'job'      => 'var_log_messages',
-#               'host'     => $facts['networking']['fqdn'],
-#               '__path__' => '/var/log/messages',
-#             },
-#           },
-#         ],
-#       },
-#     ],
-#   }
-#
+# @example
 #   class { 'promtail':
 #     config_hash           => $config_hash,
 #     password_file_path    => '/etc/promtail/.gc_pw',
 #     password_file_content => Sensitive('myPassword'),
 #   }
 #
+# @example Settings in a Hiera file
+#   ---
+#   promtail::password_file_path: '/etc/promtail/.gc_pw'
+#   promtail::password_file_content: ENC[PKCS7,MIIBasdfasdfasdfasdfasdfasdf==]
+#   promtail::server_config_hash:
+#     server:
+#       http_listen_port: 9274
+#       grpc_listen_port: 0
+#   promtail::clients_config_hash:
+#     clients:
+#       - url: 'https://logs-us-west1.grafana.net/api/prom/push'
+#         basic_auth:
+#           username: '1234'
+#           password_file: '/etc/promtail/.gc_pw'
+#   promtail::positions_config_hash:
+#     positions:
+#       filename: /tmp/positions.yaml
+#   promtail::scrape_configs_hash:
+#     scrape_configs:
+#       - job_name: system_secure
+#         entry_parser: raw
+#         static_configs:
+#         - targets:
+#             - localhost
+#           labels:
+#             job: var_log_secure
+#             host: "%{facts.networking.fqdn}"
+#             __path__: /var/log/secure
+#       - job_name: system_messages
+#         entry_parser: raw
+#         static_configs:
+#         - targets:
+#             - localhost
+#           labels:
+#             job: var_log_messages
+#             host: "%{facts.networking.fqdn}"
+#             __path__: /var/log/messages
+#
 class promtail (
-  Hash $config_hash,
+  Enum['running', 'stopped'] $service_ensure,
+  Hash $clients_config_hash,
+  Hash $positions_config_hash,
+  Hash $scrape_configs_hash,
   Stdlib::Absolutepath $bin_dir,
   String[1] $checksum,
   String[1] $version,
+  Optional[Hash] $server_config_hash = undef,
+  Optional[Hash] $target_config_hash = undef,
   Optional[Stdlib::Absolutepath] $password_file_path = undef,
   Optional[Sensitive[String[1]]] $password_file_content = undef,
 ){

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -12,7 +12,7 @@ class promtail::service {
       }
 
       service { 'promtail':
-        ensure  => running,
+        ensure  => $promtail::service_ensure,
         require => Systemd::Unit_file['promtail.service'],
       }
     }

--- a/metadata.json
+++ b/metadata.json
@@ -17,6 +17,10 @@
       "version_requirement": ">= 4.2.0 < 5.0.0"
     },
     {
+      "name": "puppetlabs/concat",
+      "version_requirement": ">= 6.0.0 < 7.0.0"
+    },
+    {
       "name": "puppetlabs/stdlib",
       "version_requirement": ">= 6.0.0 < 7.0.0"
     }

--- a/metadata.json
+++ b/metadata.json
@@ -69,7 +69,7 @@
       "version_requirement": ">= 4.10.0 < 7.0.0"
     }
   ],
-  "pdk-version": "1.13.0",
-  "template-url": "pdk-default#1.13.0",
-  "template-ref": "1.13.0-0-g66e1443"
+  "pdk-version": "1.14.0",
+  "template-url": "pdk-default#1.14.0",
+  "template-ref": "1.14.0-0-g1bf3a4e"
 }

--- a/spec/classes/config_spec.rb
+++ b/spec/classes/config_spec.rb
@@ -6,49 +6,55 @@ describe 'promtail::config' do
       context 'with valid params' do
         let(:facts) { os_facts }
         let(:pre_condition) do
-          "$config_hash = {
-            'client'         => {
-              'url'        => 'https://logs-us-west1.grafana.net/api/prom/push',
-              'basic_auth' => {
-                'username'      => '1234',
-                'password_file' => '/etc/promtail/.gc_pw',
-              },
-            },
-            'scrape_configs' => [
-              {
-                'job_name'       => 'system',
-                'entry_parser'   => 'raw',
-                'static_configs' => [
-                  {
-                    'targets' => [ 'localhost' ],
-                    'labels'  => {
-                      'job'      => 'var_log_messages',
-                      'host'     => $facts['networking']['fqdn'],
-                      '__path__' => '/var/log/messages',
-                    },
-                  },
-                ],
-              },
-            ],
-          }
-
-          class { 'promtail':
-            config_hash           => $config_hash,
+          "class { 'promtail':
             password_file_path    => '/etc/promtail/.gc_pw',
             password_file_content => Sensitive('myPassword'),
+            server_config_hash    => {
+              'server' => {
+                'http_listen_port' => 9274,
+                'grpc_listen_port' => 0,
+              },
+            },
+            clients_config_hash => {
+              'clients' => [{
+                'url'        => 'https://logs-us-west1.grafana.net/api/prom/push',
+                'basic_auth' => {
+                  'username' => '1234',
+                  'password_file' => '/etc/promtail/.gc_pw',
+                },
+              }],
+            },
+            positions_config_hash => {
+              'positions' => {
+                'filename' => '/tmp/positions.yaml',
+              },
+            },
+            scrape_configs_hash => {
+              'scrape_configs' => [{
+                'job_name'       => 'system_secure',
+                'entry_parser'   => 'raw',
+                'static_configs' => [{
+                  'targets' => [ 'localhost' ],
+                  'labels'  => {
+                    'job'      => 'var_log_secure',
+                    'host'     => $facts['networking']['fqdn'],
+                    '__path__' => '/var/log/messages',
+                  },
+                }],
+              }],
+            },
           }"
         end
 
         it { is_expected.to compile }
+        it { is_expected.to contain_file('/etc/promtail').with_ensure('directory') }
         it { is_expected.to contain_file('/etc/promtail/.gc_pw') }
-        it { is_expected.to contain_file('/etc/promtail/config.yaml').with_content(%r{^---.client}m) }
-        it { is_expected.to contain_file('/etc/promtail/config.yaml').with_content(%r{\s+__path__: "/var/log/messages"$}) }
-      end
-      context 'without a config_hash provided' do
-        let(:facts) { os_facts }
-        let(:pre_condition) { 'include promtail' }
-
-        it { is_expected.to compile.and_raise_error(%r{expects a value for parameter 'config_hash'}) }
+        it { is_expected.to contain_concat('/etc/promtail/config.yaml') }
+        it { is_expected.to contain_concat__fragment('config_header').with_content("---\n") }
+        it { is_expected.to contain_concat__fragment('server_config_hash').with_content(%r{\s+http_listen_port: 9274$}) }
+        it { is_expected.to contain_concat__fragment('clients_config_hash').with_content(%r{\s+password_file: "/etc/promtail/.gc_pw"$}) }
+        it { is_expected.to contain_concat__fragment('positions_config_hash').with_content(%r{\s+filename: "/tmp/positions.yaml"$}) }
+        it { is_expected.to contain_concat__fragment('scrape_configs_hash').with_content(%r{\s+__path__: "/var/log/messages"$}) }
       end
     end
   end

--- a/spec/classes/install_spec.rb
+++ b/spec/classes/install_spec.rb
@@ -6,46 +6,49 @@ describe 'promtail::install' do
       context 'with valid params' do
         let(:facts) { os_facts }
         let(:pre_condition) do
-          "$config_hash = {
-            'client'         => {
-              'url'        => 'https://logs-us-west1.grafana.net/api/prom/push',
-              'basic_auth' => {
-                'username'      => '1234',
-                'password_file' => '/etc/promtail/.gc_pw',
-              },
-            },
-            'scrape_configs' => [
-              {
-                'job_name'       => 'system',
-                'entry_parser'   => 'raw',
-                'static_configs' => [
-                  {
-                    'targets' => [ 'localhost' ],
-                    'labels'  => {
-                      'job'      => 'var_log_messages',
-                      'host'     => $facts['networking']['fqdn'],
-                      '__path__' => '/var/log/messages',
-                    },
-                  },
-                ],
-              },
-            ],
-          }
-
-          class { 'promtail':
-            config_hash           => $config_hash,
+          "class { 'promtail':
             password_file_path    => '/etc/promtail/.gc_pw',
             password_file_content => Sensitive('myPassword'),
+            server_config_hash    => {
+              'server' => {
+                'http_listen_port' => 9274,
+                'grpc_listen_port' => 0,
+              },
+            },
+            clients_config_hash => {
+              'clients' => [{
+                'url'        => 'https://logs-us-west1.grafana.net/api/prom/push',
+                'basic_auth' => {
+                  'username' => '1234',
+                  'password_file' => '/etc/promtail/.gc_pw',
+                },
+              }],
+            },
+            positions_config_hash => {
+              'positions' => {
+                'filename' => '/tmp/positions.yaml',
+              },
+            },
+            scrape_configs_hash => {
+              'scrape_configs' => [{
+                'job_name'       => 'system_secure',
+                'entry_parser'   => 'raw',
+                'static_configs' => [{
+                  'targets' => [ 'localhost' ],
+                  'labels'  => {
+                    'job'      => 'var_log_secure',
+                    'host'     => $facts['networking']['fqdn'],
+                    '__path__' => '/var/log/messages',
+                  },
+                }],
+              }],
+            },
           }"
         end
 
         it { is_expected.to compile }
-      end
-      context 'without a config_hash provided' do
-        let(:facts) { os_facts }
-        let(:pre_condition) { 'include promtail' }
-
-        it { is_expected.to compile.and_raise_error(%r{expects a value for parameter 'config_hash'}) }
+        it { is_expected.to contain_file('/usr/local/bin/promtail').with_ensure('link') }
+        it { is_expected.to contain_file('/usr/local/promtail_data').with_ensure('directory') }
       end
     end
   end

--- a/spec/classes/service_spec.rb
+++ b/spec/classes/service_spec.rb
@@ -6,46 +6,49 @@ describe 'promtail::service' do
       context 'with valid params' do
         let(:facts) { os_facts }
         let(:pre_condition) do
-          "$config_hash = {
-            'client'         => {
-              'url'        => 'https://logs-us-west1.grafana.net/api/prom/push',
-              'basic_auth' => {
-                'username'      => '1234',
-                'password_file' => '/etc/promtail/.gc_pw',
-              },
-            },
-            'scrape_configs' => [
-              {
-                'job_name'       => 'system',
-                'entry_parser'   => 'raw',
-                'static_configs' => [
-                  {
-                    'targets' => [ 'localhost' ],
-                    'labels'  => {
-                      'job'      => 'var_log_messages',
-                      'host'     => $facts['networking']['fqdn'],
-                      '__path__' => '/var/log/messages',
-                    },
-                  },
-                ],
-              },
-            ],
-          }
-
-          class { 'promtail':
-            config_hash           => $config_hash,
+          "class { 'promtail':
             password_file_path    => '/etc/promtail/.gc_pw',
             password_file_content => Sensitive('myPassword'),
+            server_config_hash    => {
+              'server' => {
+                'http_listen_port' => 9274,
+                'grpc_listen_port' => 0,
+              },
+            },
+            clients_config_hash => {
+              'clients' => [{
+                'url'        => 'https://logs-us-west1.grafana.net/api/prom/push',
+                'basic_auth' => {
+                  'username' => '1234',
+                  'password_file' => '/etc/promtail/.gc_pw',
+                },
+              }],
+            },
+            positions_config_hash => {
+              'positions' => {
+                'filename' => '/tmp/positions.yaml',
+              },
+            },
+            scrape_configs_hash => {
+              'scrape_configs' => [{
+                'job_name'       => 'system_secure',
+                'entry_parser'   => 'raw',
+                'static_configs' => [{
+                  'targets' => [ 'localhost' ],
+                  'labels'  => {
+                    'job'      => 'var_log_secure',
+                    'host'     => $facts['networking']['fqdn'],
+                    '__path__' => '/var/log/messages',
+                  },
+                }],
+              }],
+            },
           }"
         end
 
         it { is_expected.to compile }
-      end
-      context 'without a config_hash provided' do
-        let(:facts) { os_facts }
-        let(:pre_condition) { 'include promtail' }
-
-        it { is_expected.to compile.and_raise_error(%r{expects a value for parameter 'config_hash'}) }
+        it { is_expected.to contain_service('promtail') }
+        it { is_expected.to contain_systemd__unit_file('promtail.service') }
       end
     end
   end

--- a/spec/default_facts.yml
+++ b/spec/default_facts.yml
@@ -3,5 +3,6 @@
 # Facts specified here will override the values provided by rspec-puppet-facts.
 ---
 ipaddress: "172.16.254.254"
+ipaddress6: "FE80:0000:0000:0000:AAAA:AAAA:AAAA"
 is_pe: false
 macaddress: "AA:AA:AA:AA:AA:AA"


### PR DESCRIPTION
Settings such as the scrape configs may need to be set in multiple places in hiera and then merged into a single final setting. This fixes #2